### PR TITLE
Needs to be named melotts, prepare for pip package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class PostDevelopCommand(develop):
         os.system('python -m unidic download')
 
 setup(
-    name='melo',
+    name='melotts',
     version='0.1.1',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Since the name `melo` is already taken by a different project, preparing a PR. See #24