### PR TITLE
Added fastAPI server to support streaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM python:3.9-slim
-WORKDIR /app
-COPY . /app
-
 RUN apt-get update && apt-get install -y \
     build-essential libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
 
 RUN pip install -e .
 RUN python -m unidic download
 RUN python melo/init_downloads.py
 
-CMD ["python", "./melo/app.py", "--host", "0.0.0.0", "--port", "8888"]
+# Copy entrypoint script and make it executable
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint script
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ docker run --gpus all -it -p 8888:8888 melotts
 
 Run as a FastAPI streaming server:
 ```bash
-docker run --gpus all -it -p 8888:8888 -e APP_MODE=api melott
+docker run --gpus all -it -p 8888:8888 -e APP_MODE=api melotts
 ```
 Then open [http://localhost:8888](http://localhost:8888) in your browser to use the app.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,8 +31,14 @@ docker build -t melotts .
 ```
 
 **Run Docker**
+Run as a default Gradio app:
 ```bash
 docker run --gpus all -it -p 8888:8888 melotts
+```
+
+Run as a FastAPI streaming server:
+```bash
+docker run --gpus all -it -p 8888:8888 -e APP_MODE=api melott
 ```
 Then open [http://localhost:8888](http://localhost:8888) in your browser to use the app.
 
@@ -45,6 +51,44 @@ The WebUI supports muliple languages and voices. First, follow the installation 
 ```bash
 melo-ui
 # Or: python melo/app.py
+```
+
+### Streaming API (Docker)
+One application for the streaming API could be for an AI assistant. The following block of code provides some guidance on how to read from the stream:
+```python
+import requests
+import subprocess
+
+def stream_ffplay(audio_stream):
+  ffplay_cmd = ["ffplay", "-nodisp", "-probesize", "2048", "-autoexit", "-"]
+  ffplay_proc = subprocess.Popen(ffplay_cmd, stdin=subprocess.PIPE)
+
+  for chunk in audio_stream:
+      if chunk is not None:
+          ffplay_proc.stdin.write(chunk)
+
+  # close on finish
+  ffplay_proc.stdin.close()
+  ffplay_proc.wait()
+
+def tts(text, speaker='EN-US', language='EN', speed=1):
+  res = requests.post(
+          "http://localhost:8888/stream",
+          json={
+            "text": text,
+            "language": language,
+            "speed": speed,
+            "speaker": speaker
+          },
+          stream=True,
+      )
+  for chunk in res.iter_content(chunk_size=512):
+        if chunk:
+            yield chunk
+
+stream_ffplay(
+  tts("Ahoy there matey! How goes it?")
+)
 ```
 
 ### CLI

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,7 +53,7 @@ melo-ui
 # Or: python melo/app.py
 ```
 
-### Streaming API (Docker)
+### Streaming API
 One application for the streaming API could be for an AI assistant. The following block of code provides some guidance on how to read from the stream:
 ```python
 import requests

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Default to FastAPI if no APP_MODE specified
+APP_MODE=${APP_MODE:-fastapi}
+
+if [ "$APP_MODE" = "api" ]; then
+    exec uvicorn melo.fastapi_server:app --host "0.0.0.0" --port "8888" --reload
+else
+    exec python ./melo/app.py --host "0.0.0.0" --port "8888"
+fi

--- a/melo/fastapi_server.py
+++ b/melo/fastapi_server.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, File, UploadFile
+from pydantic import BaseModel
+import io
+from melo.api import TTS
+from fastapi.responses import StreamingResponse
+
+app = FastAPI()
+
+# Initialize the TTS models as before
+device = 'auto'
+models = {
+    'EN': TTS(language='EN', device=device),
+    'ES': TTS(language='ES', device=device),
+    'FR': TTS(language='FR', device=device),
+    'ZH': TTS(language='ZH', device=device),
+    'JP': TTS(language='JP', device=device),
+    'KR': TTS(language='KR', device=device),
+}
+
+class SynthesizePayload(BaseModel):
+    text: str = 'Ahoy there matey! There she blows!'
+    language: str = 'EN'
+    speaker: str = 'EN-US'
+    speed: float = 1.0
+
+@app.post("/stream")
+async def synthesize_stream(payload: SynthesizePayload):
+    language = payload.language
+    text = payload.text
+    speaker = payload.speaker or list(models[language].hps.data.spk2id.keys())[0]
+    speed = payload.speed
+
+    def audio_stream():
+        bio = io.BytesIO()
+        models[language].tts_to_file(text, models[language].hps.data.spk2id[speaker], bio, speed=speed, format='wav')
+        audio_data = bio.getvalue()
+        yield audio_data
+
+    return StreamingResponse(audio_stream(), media_type="audio/wav")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ jieba==0.42.1
 gradio
 langid==1.1.6
 tqdm
+fastapi
+uvicorn 
+pydantic


### PR DESCRIPTION
Summary of changes:

- Added FastAPI server with endpoint that supports streaming
- Modified Dockerfile to allow switching between Gradio app or API server through the use of the `APP_MODE` env var
- Added supporting documentation to install.md to guide users on how to utilize the streaming API server for their use case