### PR TITLE
Make training files parsable on windows

### DIFF
--- a/melo/utils.py
+++ b/melo/utils.py
@@ -269,12 +269,12 @@ def get_hparams(init=True):
     config_path = args.config
     config_save_path = os.path.join(model_dir, "config.json")
     if init:
-        with open(config_path, "r") as f:
+        with open(config_path, "r",encoding="utf8") as f:
             data = f.read()
-        with open(config_save_path, "w") as f:
+        with open(config_save_path, "w",encoding="utf8") as f:
             f.write(data)
     else:
-        with open(config_save_path, "r") as f:
+        with open(config_save_path, "r",encoding="utf8") as f:
             data = f.read()
     config = json.loads(data)
 


### PR DESCRIPTION
been experimenting on windows and this is basically what breaks it, not sure if just adding different encoding ruins it on other plattforms though...

also the "train.sh" script doesn't work, can just run it using
`torchrun train.py -c <config_path> --model <model_name>`