### PR TITLE
adding support to install on Debian 12

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,6 +18,11 @@ python -m unidic download
 ```
 If you encountered issues in macOS install, try the [Docker Install](#docker-install)
 
+#### System requirements
+On Debian 12, you may need to install the following packages:
+- libmecab-dev
+- python3-mecab
+
 ### Docker Install
 To avoid compatibility issues, for Windows users and some macOS users, we suggest to run via Docker. Ensure that [you have Docker installed](https://docs.docker.com/engine/install/).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 txtsplit
-torch<2.0
+torch
 torchaudio
 cached_path
 transformers==4.27.4
@@ -7,6 +7,7 @@ mecab-python3==1.0.5
 num2words==0.5.12
 unidic_lite==1.0.8
 unidic==1.1.0
+fugashi
 mecab-python3==1.0.5
 pykakasi==2.2.1
 fugashi==1.3.0


### PR DESCRIPTION
On a Debian 12, I faced multiple issues to install MeloTTS locally. Here are the results of my fixes

1. `torch` pip package should not be limited to versions bellow 2.0. This generates some conflict with `torchaudio`. The version I use for torch is 2.2.1. This works fine
2. fugashi pip package is necessary to support mecab-config. Otherwise, we have a "mecab-config: no such file or directory" during the installation. Moreover, I had to install `mecab-python3` and `libmecab-dev` application on the system (with apt)

That's enough. I didn't face any problem at usage. I tested EN and FR language generation

I didn't test this install on other systems