### PR TITLE
Support python 3.12.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 
 *.zip
 *.wav
+.venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ txtsplit
 torch
 torchaudio
 cached_path
-transformers==4.27.4
+# transformers==4.27.4
+transformers
 mecab-python3==1.0.5
 num2words==0.5.12
 unidic_lite==1.0.8


### PR DESCRIPTION
This fixes error while rust builds for tokenizers wheels on python 3.12

```
error: `cargo rustc --lib --message-format=json-render-diagnostics --manifest-path Cargo.toml --release -v --features pyo3/extension-module --crate-type cdylib --` failed with code 101
```