### PR TITLE
Update dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 WORKDIR /app
 COPY . /app
 


### PR DESCRIPTION
This project depends from Python 3.10. Update Dockerfile base image to `python:3.10-slim` so Docker image build works as expected.