### PR TITLE
Fix urllib3 conflict by pinning Gradio to 4.26.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ unidecode==1.3.7
 pypinyin==0.50.0
 cn2an==0.5.22
 jieba==0.42.1
-gradio
+gradio==4.26.0
 langid==1.1.6
 tqdm
 tensorboard==2.16.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ unidecode==1.3.7
 pypinyin==0.50.0
 cn2an==0.5.22
 jieba==0.42.1
-gradio==4.26.0
+gradio<=4.26.0
 langid==1.1.6
 tqdm
 tensorboard==2.16.2


### PR DESCRIPTION
While installing MeloTTS with Python 3.9.22, a version conflict arose due to incompatible urllib3 requirements between gradio and botocore==1.38.16 (a dependency of cached_path).

Since gradio was not pinned in requirements.txt, the latest version (4.44.1) was being installed. This version depends on a higher version of urllib3 than allowed by botocore==1.38.16, resulting in a dependency conflict.

This commit pins gradio to version 4.26.0, which uses a lower urllib3 version compatible with botocore==1.38.16, resolving the issue.