### PR TITLE
Document Apple Silicon MPS macOS workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Some other features include:
 
 The Python API and model cards can be found in [this repo](https://github.com/myshell-ai/MeloTTS/blob/main/docs/install.md#python-api) or on [HuggingFace](https://huggingface.co/myshell-ai).
 
+## Troubleshooting
+
+### Apple Silicon MPS error: `Output channels > 65536 not supported at the MPS device`
+
+If you hit this error on Apple Silicon when running on `device='mps'`, update macOS first. In our verification, the same MeloTTS code and Python environment stopped reproducing the issue after updating to macOS `26.3.1`.
+
+If it still reproduces after a macOS update, please open an issue with your macOS version, PyTorch version, and a minimal failing text sample.
 **Contributing**
 
 If you find this work useful, please consider contributing to this repo.


### PR DESCRIPTION
## Summary
- add a troubleshooting note for the Apple Silicon MPS output channel limit error
- document that updating macOS resolved the issue in local verification
- ask users to report macOS version, PyTorch version, and a minimal failing text sample if it still reproduces

## Verification
- reproduced the MPS failure on an older macOS release
- re-ran the same MeloTTS code and Python environment after updating macOS
- verified MPS synthesis for: I am fine.
- verified MPS synthesis for: I am just a bundle of circuits, but I am running smoothly.